### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -23,10 +23,12 @@ export default class ServerlessStaticLocalPlugin implements Plugin {
         port: {
           usage: `Static server port, default: ${defaults.port}`,
           shortcut: 'p',
+          type: 'string',
         },
         folder: {
           usage: `Static folder path, default: ${defaults.folder}`,
           shortcut: 'f',
+          type: 'string',
         },
       },
     },


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessStaticLocalPlugin for "port", "folder"
```